### PR TITLE
SecretsHelper Refactoring through JSON Parsing

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -6,11 +6,12 @@
         <sourceOutputDir name="target/generated-sources/annotations" />
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
         <outputRelativeToContentRoot value="true" />
-        <module name="PhamKornbluhGroup" />
+        <module name="POEDataVisualizer" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel>
       <module name="PhamKornbluhGroup" target="17" />
+      <module name="POEDataVisualizer" target="17" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/PhamKornbluhGroup.iml" filepath="$PROJECT_DIR$/.idea/PhamKornbluhGroup.iml" />
+      <module fileurl="file://$PROJECT_DIR$/POEDataVisualizer.iml" filepath="$PROJECT_DIR$/POEDataVisualizer.iml" />
     </modules>
   </component>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,23 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>auth</artifactId>
         </dependency>
+
+        <!-- Jackson JSON Parsing Tools -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version> 2.13.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.13.3</version>
+        </dependency>
     </dependencies>
 
     <!-- Build Section -->

--- a/src/main/java/com/PhamKornbluhGroup/SecretsHelper.java
+++ b/src/main/java/com/PhamKornbluhGroup/SecretsHelper.java
@@ -67,41 +67,6 @@ public class SecretsHelper {
         return "TOKEN_DEFAULT_RETURN";
     }
 
-    // TODO: After using JSON parsing, can combine both of these methods into a single method:
-    //  #1 formatGGGBearerToken
-    //  #2 formatGGGBearerTokenUserAgent
-    private static String formatGGGBearerToken(String gggBearerToken) {
-        String token = "";
-        try {
-            ObjectMapper mapper = new ObjectMapper();
-            JsonNode node = mapper.readTree(gggBearerToken);
-            token = node.get("GGGBearerToken").asText();
-        }
-        catch (Exception e) {
-            // TODO: Add Logging
-            // TODO: Specify which exceptions
-            System.out.println(e.getMessage());
-        }
-        return token;
-    }
-
-    private static String formatGGGBearerTokenUserAgent(String gggUserAgentToken) {
-        // Token returns a json object. Substring can be replaced with json parser
-        // TODO: Consider using Jackson for parsing
-        String token = "";
-        try {
-            ObjectMapper mapper = new ObjectMapper();
-            JsonNode node = mapper.readTree(gggUserAgentToken);
-            token = node.get("User-Agent").asText();
-        }
-        catch (Exception e) {
-            // TODO: Add Logging
-            // TODO: Specify which exceptions
-            System.out.println(e.getMessage());
-        }
-        return token;
-    }
-
     private static String parseJsonToken(String jsonToken, String key) {
         String parsedToken = "";
         try {

--- a/src/main/java/com/PhamKornbluhGroup/SecretsHelper.java
+++ b/src/main/java/com/PhamKornbluhGroup/SecretsHelper.java
@@ -13,18 +13,20 @@ public class SecretsHelper {
     // https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/home.html
 
     public static String[] getFormattedGGGBearerToken() {
+        //p For this method to work, the name of the secret must be the same as the value of the secret's key
         String tokenName = "GGGBearerToken";
         String secret = getSecretsManagerSecret(tokenName);
-        String formattedSecret = formatGGGBearerToken(secret);
+        String formattedSecret = parseJsonToken(secret, tokenName);
 
         String[] keyValue = new String[] {"Authorization", formattedSecret};
         return keyValue;
     }
 
     public static String[] getFormattedGGGBearerTokenUserAgent() {
+        //p For this method to work, the name of the secret must be the same as the secret's key
         String tokenName = "GGGBearerToken_User-Agent";
         String secret = getSecretsManagerSecret(tokenName);
-        String formattedSecret = formatGGGBearerTokenUserAgent(secret);
+        String formattedSecret = parseJsonToken(secret, tokenName);
 
         String[] keyValue = new String[] {"User-Agent", formattedSecret};
         return keyValue;
@@ -98,5 +100,20 @@ public class SecretsHelper {
             System.out.println(e.getMessage());
         }
         return token;
+    }
+
+    private static String parseJsonToken(String jsonToken, String key) {
+        String parsedToken = "";
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode node = mapper.readTree(jsonToken);
+            parsedToken = node.get(key).asText();
+        }
+        catch (Exception e) {
+            // TODO: Add Logging
+            // TODO: Specify which exceptions
+            System.out.println(e.getMessage());
+        }
+        return parsedToken;
     }
 }

--- a/src/main/java/com/PhamKornbluhGroup/SecretsHelper.java
+++ b/src/main/java/com/PhamKornbluhGroup/SecretsHelper.java
@@ -13,7 +13,7 @@ public class SecretsHelper {
     // https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/home.html
 
     public static String[] getFormattedGGGBearerToken() {
-        //p For this method to work, the name of the secret must be the same as the value of the secret's key
+        //p For this method to work, the name of the secret must be the same as the secret's key
         String tokenName = "GGGBearerToken";
         String secret = getSecretsManagerSecret(tokenName);
         String formattedSecret = parseJsonToken(secret, tokenName);

--- a/src/main/java/com/PhamKornbluhGroup/SecretsHelper.java
+++ b/src/main/java/com/PhamKornbluhGroup/SecretsHelper.java
@@ -83,9 +83,20 @@ public class SecretsHelper {
         return token;
     }
 
-    private static String formatGGGBearerTokenUserAgent(String gggBearerToken) {
+    private static String formatGGGBearerTokenUserAgent(String gggUserAgentToken) {
         // Token returns a json object. Substring can be replaced with json parser
         // TODO: Consider using Jackson for parsing
-        return gggBearerToken.substring(15,80);
+        String token = "";
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode node = mapper.readTree(gggUserAgentToken);
+            token = node.get("User-Agent").asText();
+        }
+        catch (Exception e) {
+            // TODO: Add Logging
+            // TODO: Specify which exceptions
+            System.out.println(e.getMessage());
+        }
+        return token;
     }
 }

--- a/src/main/java/com/PhamKornbluhGroup/SecretsHelper.java
+++ b/src/main/java/com/PhamKornbluhGroup/SecretsHelper.java
@@ -1,5 +1,7 @@
 package com.PhamKornbluhGroup;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
@@ -67,9 +69,18 @@ public class SecretsHelper {
     //  #1 formatGGGBearerToken
     //  #2 formatGGGBearerTokenUserAgent
     private static String formatGGGBearerToken(String gggBearerToken) {
-        // Token returns a json object. Substring can be replaced with json parser
-        // TODO: Consider using Jackson for parsing
-        return "Bearer " + gggBearerToken.substring(19,59);
+        String token = "";
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode node = mapper.readTree(gggBearerToken);
+            token = node.get("GGGBearerToken").asText();
+        }
+        catch (Exception e) {
+            // TODO: Add Logging
+            // TODO: Specify which exceptions
+            System.out.println(e.getMessage());
+        }
+        return token;
     }
 
     private static String formatGGGBearerTokenUserAgent(String gggBearerToken) {


### PR DESCRIPTION
### **First Section - Changes Outside Code:**

**#1a - In AWS, update secret "GGGBearerToken" VALUE to include "Bearer "**
`Reasoning: Since the return was always "Bearer " + value, the logic can be simplified by updating the secret value itself
`

**#1b  - In AWS, update secret "GGGBearerToken_User-Agent" KEY to be the same as the secret name**
`Reasoning: This allows the same tokenName variable to be used for both fetching Secret itself, and for parsing the JSON. To avoid confusion, a comment was added to relevant methods indicating that further changes to the secrets will break the secret getters.`

### **Second Section - JSON Parsing**

**#2a - Update POM to include Jackson Dependencies for JSON Parsing**

**#2b - Create new SecretsHelper.parseJsonToken method to replace the following methods, and delete the now-unused methods:**
- formatGGGBearerToken (NOW DELETED)
- formatGGGBearerTokenUserAgent (NOW DELETED)

`Reasoning: These methods were hardcoded to grab substrings, and we decided it would be cleaner to do JSON Parsing`


**#2c - Refactor the following SecretsHelper methods to use new parseJsonToken method:** 
- getFormattedGGGBearerToken
- getFormattedGGGBearerTokenUserAgent